### PR TITLE
fix: enhance `shift()` to support `pl.all()`

### DIFF
--- a/src/turtle_island/exprs/general.py
+++ b/src/turtle_island/exprs/general.py
@@ -409,18 +409,17 @@ def shift(expr: pl.Expr, offset: int = 1, *, fill_expr: pl.Expr) -> pl.Expr:
         raise ValueError("`offset=` must be an integer.")
     if offset == 0:
         return expr
-    name = expr.meta.output_name()
     shifted_expr = expr.shift(offset)
     index_expr = make_index(name=_get_unique_name())
     if offset > 0:
         # n is positive => pre_filled
-        expr = case_when([(index_expr.lt(offset), fill_expr)], shifted_expr)
+        expr = case_when([(index_expr.ge(offset), shifted_expr)], fill_expr)
     else:
         # n is negative => back_filled
         expr = case_when(
-            [(index_expr.ge(pl.len() + offset), fill_expr)], shifted_expr
+            [(index_expr.lt(pl.len() + offset), shifted_expr)], fill_expr
         )
-    return expr.alias(name)
+    return expr
 
 
 def cycle(expr, offset: int = 1) -> pl.Expr:

--- a/tests/exprs/test_general.py
+++ b/tests/exprs/test_general.py
@@ -372,6 +372,14 @@ def test_shift_default(df_x):
     assert_frame_equal(new_df, expected)
 
 
+def test_shift_pl_all(df_xy):
+    new_df = df_xy.with_columns(
+        ti.shift(pl.all(), fill_expr=pl.col("y").alias("z").add(100))
+    )
+    expected = pl.DataFrame({"x": [105, 1, 2, 3], "y": [105, 5, 6, 7]})
+    assert_frame_equal(new_df, expected)
+
+
 def test_shift_n_zero_return_self():
     expr = pl.col("x")
     expected = ti.shift(expr, 0, fill_expr=pl.col("x").add(100))


### PR DESCRIPTION
Fixes #1

This PR adds support for `pl.all()` in `shift()` by updating the internal `case_when()` logic. The `shifted_expr` is now placed as the first entry in the `case_when()` expression, allowing it to determine the column names directly. As a result, there's no longer a need to rely on `pl.Expr.meta.output_name()` beforehand.

