### PR TITLE
refactor: `shift()`

### DIFF
--- a/src/turtle_island/exprs/general.py
+++ b/src/turtle_island/exprs/general.py
@@ -413,13 +413,11 @@ def shift(expr: pl.Expr, offset: int = 1, *, fill_expr: pl.Expr) -> pl.Expr:
     index_expr = make_index(name=_get_unique_name())
     if offset > 0:
         # n is positive => pre_filled
-        expr = case_when([(index_expr.ge(offset), shifted_expr)], fill_expr)
+        caselist = [(index_expr.ge(offset), shifted_expr)]
     else:
         # n is negative => back_filled
-        expr = case_when(
-            [(index_expr.lt(pl.len() + offset), shifted_expr)], fill_expr
-        )
-    return expr
+        caselist = [(index_expr.lt(pl.len() + offset), shifted_expr)]
+    return case_when(caselist, fill_expr)
 
 
 def cycle(expr, offset: int = 1) -> pl.Expr:


### PR DESCRIPTION
This PR refactors `shift()` to avoid reassigning the `expr`.