### PR TITLE
fix: remove `name=` parameter from functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,9 @@ shape: (3, 3)
 Assign values to rows in a round-robin pattern using Polars expressions:
 ```python
 df = pl.DataFrame({"x": [1, 2, 3, 4, 5]})
-df.with_columns(ti.bucketize(pl.col("x"), pl.col("x").add(100)))
+df.with_columns(
+    ti.bucketize(pl.col("x"), pl.col("x").add(100)).alias("bucketized")
+)
 ```
 ```
 shape: (5, 2)
@@ -111,7 +113,7 @@ shape: (5, 2)
 Assign values to rows in a round-robin pattern using literal values:
 ```python
 df = pl.DataFrame({"x": [1, 2, 3, 4, 5]})
-df.with_columns(ti.bucketize_lit(True, False))
+df.with_columns(ti.bucketize_lit(True, False).alias("bucketized"))
 ```
 ```
 shape: (5, 2)

--- a/src/turtle_island/_utils.py
+++ b/src/turtle_island/_utils.py
@@ -48,9 +48,7 @@ def _cast_datatype(expr: pl.Expr, item: Any) -> pl.Expr:
     return expr
 
 
-def _concat_str(
-    template: str, *col_names: str, name: str, sep: str = "**X**"
-) -> pl.Expr:
+def _concat_str(template: str, *col_names: str, sep: str = "**X**") -> pl.Expr:
     if not all(isinstance(col_name, str) for col_name in col_names):
         raise ValueError("All column names must be of type string.")
     splitted = template.split(sep)
@@ -66,4 +64,4 @@ def _concat_str(
         concat_str_list.append(lit)
         if col_name := next(col_names_iter, None):
             concat_str_list.append(col_name)
-    return pl.concat_str(concat_str_list).alias(name)
+    return pl.concat_str(concat_str_list)

--- a/src/turtle_island/exprs/_helpers.py
+++ b/src/turtle_island/exprs/_helpers.py
@@ -10,7 +10,7 @@ from .core import make_index
 
 
 def _make_bucketize_casewhen(
-    exprs: Collection[Any], *, is_litify: bool, name: str
+    exprs: Collection[Any], *, is_litify: bool
 ) -> pl.Expr:
     if is_litify:
         # turn items into exprs
@@ -21,7 +21,7 @@ def _make_bucketize_casewhen(
     caselist: list[tuple[pl.Expr, pl.Expr]] = [
         (mod_expr.eq(i), expr) for i, expr in enumerate(whenthen_exprs)
     ]
-    return case_when(caselist, otherwise_expr).alias(name)
+    return case_when(caselist, otherwise_expr)
 
 
 def _get_move_cols(

--- a/src/turtle_island/exprs/core.py
+++ b/src/turtle_island/exprs/core.py
@@ -6,11 +6,11 @@ __all__ = [
 ]
 
 
-def _make_index(start: int, end: int | pl.Expr, *, name: str) -> pl.Expr:
-    return pl.int_range(start, end, dtype=pl.UInt32).alias(name)
+def _make_index(start: int, end: int | pl.Expr) -> pl.Expr:
+    return pl.int_range(start, end, dtype=pl.UInt32)
 
 
-def make_index(name: str = "index", offset: int = 0) -> pl.Expr:
+def make_index(offset: int = 0, *, name: str = "index") -> pl.Expr:
     """
     Returns a Polars expression that creates a virtual row index.
 
@@ -24,6 +24,7 @@ def make_index(name: str = "index", offset: int = 0) -> pl.Expr:
     ----------
     name
         The name to assign to the generated index column.
+
     offset
         Start the index at this offset. Cannot be negative.
 
@@ -43,4 +44,4 @@ def make_index(name: str = "index", offset: int = 0) -> pl.Expr:
     df.select(ti.make_index(), pl.all())
     ```
     """
-    return _make_index(0, pl.len(), name=name).add(offset)
+    return _make_index(0, pl.len()).add(offset).alias(name)

--- a/src/turtle_island/exprs/html.py
+++ b/src/turtle_island/exprs/html.py
@@ -21,11 +21,14 @@ def make_hyperlink(
     ----------
     text
         Column name containing the display text for the hyperlink.
+
     url
         Column name containing the destination URL.
+
     new_tab
         Whether the link opens in a new browser tab (`target="_blank"`) or the current tab.
         Defaults to `True`.
+
     name
         The name of the resulting column. Defaults to "hyperlink".
 
@@ -56,8 +59,8 @@ def make_hyperlink(
     """
     target = "_blank" if new_tab else "_self"
     return _concat_str(
-        f'<a href="**X**" target="{target}">**X**</a>', url, text, name=name
-    )
+        f'<a href="**X**" target="{target}">**X**</a>', url, text
+    ).alias(name)
 
 
 def make_tooltip(
@@ -80,14 +83,17 @@ def make_tooltip(
     ----------
     label
         Column name containing the main text to display.
+
     tooltip
         Column name containing containing the text shown when hovering over the label.
 
     text_decoration_style
         A string indicating the style of underline decoration. Options are `"solid"`,
         `"dotted"`, or `"none"`.
+
     color
         A string indicating the text color. If "none", no color styling is applied.
+
     name
         The name of the resulting column. Defaults to "tooltip".
 
@@ -137,8 +143,5 @@ def make_tooltip(
         style += f"color: {color}; "
 
     return _concat_str(
-        f'<abbr style="{style}" title="**X**">**X**</abbr>',
-        tooltip,
-        label,
-        name=name,
-    )
+        f'<abbr style="{style}" title="**X**">**X**</abbr>', tooltip, label
+    ).alias(name)

--- a/tests/exprs/test_core.py
+++ b/tests/exprs/test_core.py
@@ -67,12 +67,11 @@ def test_make_index_index_column_exist(df_x, offset):
     ],
 )
 def test_bucketize_index_column_exist(df_n, exprs, result):
+    name = "bucketized"
     _df = df_n.with_row_index()
     # intentionally use `with_columns()`
-    new_df = _df.with_columns(ti.bucketize(*exprs))
-    expected = pl.concat(
-        [_df, pl.DataFrame({"bucketized": result})], how="horizontal"
-    )
+    new_df = _df.with_columns(ti.bucketize(*exprs).alias(name))
+    expected = pl.concat([_df, pl.DataFrame({name: result})], how="horizontal")
     assert_frame_equal(new_df, expected)
 
 

--- a/tests/exprs/test_general.py
+++ b/tests/exprs/test_general.py
@@ -76,16 +76,9 @@ def test_move_cols_to_end(df_abcd, columns, result):
     ],
 )
 def test_bucketize_lit(df_n, items, result):
-    new_df = df_n.select(ti.bucketize_lit(*items))
-    expected = pl.DataFrame({"bucketized": result})
-
-    assert_frame_equal(new_df, expected)
-
-
-@pytest.mark.parametrize("name", ["cool_name"])
-def test_bucketize_lit_alias(df_n, name):
-    new_df = df_n.select(ti.bucketize_lit(1, 2, name=name))
-    expected = pl.DataFrame({name: [1, 2, 1, 2, 1, 2, 1, 2, 1]})
+    name = "bucketized"
+    new_df = df_n.select(ti.bucketize_lit(*items).alias(name))
+    expected = pl.DataFrame({name: result})
 
     assert_frame_equal(new_df, expected)
 
@@ -103,23 +96,27 @@ def test_bucketize_lit_alias(df_n, name):
     ],
 )
 def test_bucketize_lit_coalesce_to(df_n, items, result, coalesce_to):
-    new_df = df_n.select(ti.bucketize_lit(*items, coalesce_to=coalesce_to))
-    expected = pl.DataFrame({"bucketized": result})
+    name = "bucketized"
+    new_df = df_n.select(
+        ti.bucketize_lit(*items, coalesce_to=coalesce_to).alias(name)
+    )
+    expected = pl.DataFrame({name: result})
 
     assert_frame_equal(new_df, expected)
 
 
 def test_bucketize_lit_multicols(df_n):
+    binarized, trinarized, bucketized = "binarized", "trinarized", "bucketized"
     new_df = df_n.select(
-        ti.bucketize_lit(1, 2, name="binarized"),
-        ti.bucketize_lit(1.1, 2.2, 3.3, name="trinarized"),
-        ti.bucketize_lit("one", "two", "three", "four", name="bucketized"),
+        ti.bucketize_lit(1, 2).alias(binarized),
+        ti.bucketize_lit(1.1, 2.2, 3.3).alias(trinarized),
+        ti.bucketize_lit("one", "two", "three", "four").alias(bucketized),
     )
     expected = pl.DataFrame(
         {
-            "binarized": [1, 2, 1, 2, 1, 2, 1, 2, 1],
-            "trinarized": [1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3],
-            "bucketized": [
+            binarized: [1, 2, 1, 2, 1, 2, 1, 2, 1],
+            trinarized: [1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3],
+            bucketized: [
                 "one",
                 "two",
                 "three",
@@ -179,16 +176,9 @@ def test_bucketize_lit_raise_not_the_same_type():
     ],
 )
 def test_bucketize(df_n, exprs, result):
-    new_df = df_n.select(ti.bucketize(*exprs))
-    expected = pl.DataFrame({"bucketized": result})
-    assert_frame_equal(new_df, expected)
-
-
-@pytest.mark.parametrize("name", ["cool_name"])
-def test_bucketize_alias(df_n, name):
-    new_df = df_n.select(ti.bucketize(pl.col("n"), pl.col("n"), name=name))
-    expected = pl.DataFrame({name: [1, 2, 3, 4, 5, 6, 7, 8, 9]})
-
+    name = "bucketized"
+    new_df = df_n.select(ti.bucketize(*exprs).alias(name))
+    expected = pl.DataFrame({name: result})
     assert_frame_equal(new_df, expected)
 
 
@@ -208,8 +198,11 @@ def test_bucketize_alias(df_n, name):
     ],
 )
 def test_bucketize_coalesce_to(df_n, exprs, result, coalesce_to):
-    new_df = df_n.select(ti.bucketize(*exprs, coalesce_to=coalesce_to))
-    expected = pl.DataFrame({"bucketized": result})
+    name = "bucketized"
+    new_df = df_n.select(
+        ti.bucketize(*exprs, coalesce_to=coalesce_to).alias(name)
+    )
+    expected = pl.DataFrame({name: result})
 
     assert_frame_equal(new_df, expected)
 

--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -57,14 +57,12 @@ def test__cast_datatype(df_abcd, item, expected):
 
 
 def test__concat_str():
-    name = "cool_name"
     quick, lazy = "quick", "lazy"
     fox, dog = "fox", "dog"
     concat_str_expr = _concat_str(
         f"The {quick} brown **X** jumps over the {lazy} **X**.",
         fox,
         dog,
-        name=name,
     )
     expected = pl.concat_str(
         [
@@ -74,13 +72,12 @@ def test__concat_str():
             dog,
             pl.lit("."),
         ]
-    ).alias(name)
+    )
 
     assert concat_str_expr.meta.eq(expected)
 
 
 def test__concat_str_sep():
-    name = "cool_name"
     quick, lazy = "quick", "lazy"
     fox, dog = "fox", "dog"
     concat_str_expr = _concat_str(
@@ -88,7 +85,6 @@ def test__concat_str_sep():
         fox,
         dog,
         sep="##<X>##",
-        name=name,
     )
     expected = pl.concat_str(
         [
@@ -98,33 +94,27 @@ def test__concat_str_sep():
             dog,
             pl.lit("."),
         ]
-    ).alias(name)
+    )
 
     assert concat_str_expr.meta.eq(expected)
 
 
 def test__concat_str_raise_col_names_not_all_str():
-    name = "cool_name"
     fox = "fox"
     with pytest.raises(ValueError) as exc_info:
         _concat_str(
-            "The quick brown **X** jumps over the lazy **X**.",
-            fox,
-            123,
-            name=name,
+            "The quick brown **X** jumps over the lazy **X**.", fox, 123
         )  # 123 is int type
 
     assert "All column names must be of type string." in exc_info.value.args[0]
 
 
 def test__concat_str_raise_params_not_match():
-    name = "cool_name"
     fox = "fox"
     with pytest.raises(ValueError) as exc_info:
         _concat_str(
             "The quick brown **X** jumps over the lazy **X**.",
             fox,
-            name=name,
         )  # `dog` is missed
 
     assert (


### PR DESCRIPTION
Fixes: #5

This PR reviews the codebase to remove unnecessary `name=` parameters from functions.

Currently, only the following functions retain the `name=` parameter. These functions are designed to explicitly create new columns, and their names clearly indicate this behavior. Therefore, the `name=` argument is preserved and enforced as keyword-only:

* `make_index()`
* `make_hyperlink()`
* `make_tooltip()`
* `is_every_nth_row()`