### PR TITLE
refactor: update the default value of `sep=` in `_concat_str()`

### DIFF
--- a/src/turtle_island/_utils.py
+++ b/src/turtle_island/_utils.py
@@ -48,7 +48,7 @@ def _cast_datatype(expr: pl.Expr, item: Any) -> pl.Expr:
     return expr
 
 
-def _concat_str(template: str, *col_names: str, sep: str = "**X**") -> pl.Expr:
+def _concat_str(template: str, *col_names: str, sep: str = "[$X]") -> pl.Expr:
     if not all(isinstance(col_name, str) for col_name in col_names):
         raise ValueError("All column names must be of type string.")
     splitted = template.split(sep)

--- a/src/turtle_island/exprs/html.py
+++ b/src/turtle_island/exprs/html.py
@@ -59,7 +59,7 @@ def make_hyperlink(
     """
     target = "_blank" if new_tab else "_self"
     return _concat_str(
-        f'<a href="**X**" target="{target}">**X**</a>', url, text
+        f'<a href="[$X]" target="{target}">[$X]</a>', url, text
     ).alias(name)
 
 
@@ -143,5 +143,5 @@ def make_tooltip(
         style += f"color: {color}; "
 
     return _concat_str(
-        f'<abbr style="{style}" title="**X**">**X**</abbr>', tooltip, label
+        f'<abbr style="{style}" title="[$X]">[$X]</abbr>', tooltip, label
     ).alias(name)

--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -60,7 +60,7 @@ def test__concat_str():
     quick, lazy = "quick", "lazy"
     fox, dog = "fox", "dog"
     concat_str_expr = _concat_str(
-        f"The {quick} brown **X** jumps over the {lazy} **X**.",
+        f"The {quick} brown [$X] jumps over the {lazy} [$X].",
         fox,
         dog,
     )
@@ -103,7 +103,7 @@ def test__concat_str_raise_col_names_not_all_str():
     fox = "fox"
     with pytest.raises(ValueError) as exc_info:
         _concat_str(
-            "The quick brown **X** jumps over the lazy **X**.", fox, 123
+            "The quick brown [$X] jumps over the lazy [$X].", fox, 123
         )  # 123 is int type
 
     assert "All column names must be of type string." in exc_info.value.args[0]
@@ -113,7 +113,7 @@ def test__concat_str_raise_params_not_match():
     fox = "fox"
     with pytest.raises(ValueError) as exc_info:
         _concat_str(
-            "The quick brown **X** jumps over the lazy **X**.",
+            "The quick brown [$X] jumps over the lazy [$X].",
             fox,
         )  # `dog` is missed
 


### PR DESCRIPTION
This PR updates the default value of the `sep=` parameter in `_concat_str()`