### PR TITLE
fix: rename `caselist` to `case_list` in `case_when()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ A more ergonomic way to write chained `when-then-otherwise` logic in Polars:
 df = pl.DataFrame({"x": [1, 2, 3, 4]})
 
 expr_ti = ti.case_when(
-    caselist=[(pl.col("x") < 2, pl.lit("small")),
-              (pl.col("x") < 4, pl.lit("medium"))],
+    case_list=[(pl.col("x") < 2, pl.lit("small")),
+               (pl.col("x") < 4, pl.lit("medium"))],
     otherwise=pl.lit("large"),
 ).alias("size_ti")
 

--- a/src/turtle_island/exprs/_helpers.py
+++ b/src/turtle_island/exprs/_helpers.py
@@ -18,10 +18,10 @@ def _make_bucketize_casewhen(
     n = len(exprs)
     mod_expr = make_index(name=_get_unique_name()).mod(n)
     *whenthen_exprs, otherwise_expr = exprs
-    caselist: list[tuple[pl.Expr, pl.Expr]] = [
+    case_list: list[tuple[pl.Expr, pl.Expr]] = [
         (mod_expr.eq(i), expr) for i, expr in enumerate(whenthen_exprs)
     ]
-    return case_when(caselist, otherwise_expr)
+    return case_when(case_list, otherwise_expr)
 
 
 def _get_move_cols(

--- a/src/turtle_island/exprs/common.py
+++ b/src/turtle_island/exprs/common.py
@@ -6,7 +6,7 @@ __all__ = ["bulk_append", "case_when"]
 
 
 def case_when(
-    caselist: Sequence[tuple[pl.Expr | tuple[pl.Expr], pl.Expr]],
+    case_list: Sequence[tuple[pl.Expr | tuple[pl.Expr], pl.Expr]],
     otherwise: pl.Expr | None = None,
 ) -> pl.Expr:
     """
@@ -23,7 +23,7 @@ def case_when(
 
     Parameters
     ----------
-    caselist
+    case_list
         A sequence of tuples where each tuple represents a `when` and `then`
         branch. This function accepts three input forms (see examples below).
         Each tuple is evaluated in order from top to bottom. For each tuple, the
@@ -60,7 +60,7 @@ def case_when(
     df = pl.DataFrame({"x": [1, 2, 3, 4], "y": [5, 6, 7, 8]})
 
     expr1 = ti.case_when(
-        caselist=[
+        case_list=[
             (pl.col("x") < 2, pl.lit("small")),
             (pl.col("x") < 4, pl.lit("medium")),
         ],
@@ -68,7 +68,7 @@ def case_when(
     ).alias("size1")
 
     expr2 = ti.case_when(
-        caselist=[
+        case_list=[
             (pl.col("x") < 3, pl.col("y") < 6, pl.lit("small")),
             (pl.col("x") < 4, pl.col("y") < 8, pl.lit("medium")),
         ],
@@ -76,7 +76,7 @@ def case_when(
     ).alias("size2")
 
     expr3 = ti.case_when(
-        caselist=[
+        case_list=[
             ((pl.col("x") < 3, pl.col("y") < 6), pl.lit("small")),
             ((pl.col("x") < 4, pl.col("y") < 8), pl.lit("medium")),
         ],
@@ -89,7 +89,7 @@ def case_when(
 
     from polars.expr.whenthen import Then
 
-    first_case, *cases = caselist
+    first_case, *cases = case_list
 
     # first
     *first_whens, first_then = first_case

--- a/src/turtle_island/exprs/general.py
+++ b/src/turtle_island/exprs/general.py
@@ -412,11 +412,11 @@ def shift(expr: pl.Expr, offset: int = 1, *, fill_expr: pl.Expr) -> pl.Expr:
     index_expr = make_index(name=_get_unique_name())
     if offset > 0:
         # n is positive => pre_filled
-        caselist = [(index_expr.ge(offset), shifted_expr)]
+        case_list = [(index_expr.ge(offset), shifted_expr)]
     else:
         # n is negative => back_filled
-        caselist = [(index_expr.lt(pl.len() + offset), shifted_expr)]
-    return case_when(caselist, fill_expr)
+        case_list = [(index_expr.lt(pl.len() + offset), shifted_expr)]
+    return case_when(case_list, fill_expr)
 
 
 def cycle(expr, offset: int = 1) -> pl.Expr:

--- a/tests/exprs/test_common.py
+++ b/tests/exprs/test_common.py
@@ -7,7 +7,7 @@ import turtle_island as ti
 
 def test_case_when(df_abcd):
     expr_ti = ti.case_when(
-        caselist=[
+        case_list=[
             (pl.col("a") < 2, pl.col("a")),
             (pl.col("a") < 3, pl.col("a") * 2),
         ],
@@ -32,7 +32,7 @@ def test_case_when(df_abcd):
 def test_case_when_lit(df_x):
     # test the expression itself
     expr_ti = ti.case_when(
-        caselist=[
+        case_list=[
             (pl.col("x") < 2, pl.lit("small")),
             (pl.col("x") < 4, pl.lit("medium")),
         ],
@@ -57,7 +57,7 @@ def test_case_when_lit(df_x):
 
 def test_case_when_all_forms(df_xy):
     expr1 = ti.case_when(
-        caselist=[
+        case_list=[
             (pl.col("x") < 2, pl.lit("small")),
             (pl.col("x") < 4, pl.lit("medium")),
         ],
@@ -65,7 +65,7 @@ def test_case_when_all_forms(df_xy):
     ).alias("size1")
 
     expr2 = ti.case_when(
-        caselist=[
+        case_list=[
             (pl.col("x") < 3, pl.col("y") < 6, pl.lit("small")),
             (pl.col("x") < 4, pl.col("y") < 8, pl.lit("medium")),
         ],
@@ -73,7 +73,7 @@ def test_case_when_all_forms(df_xy):
     ).alias("size2")
 
     expr3 = ti.case_when(
-        caselist=[
+        case_list=[
             ((pl.col("x") < 3, pl.col("y") < 6), pl.lit("small")),
             ((pl.col("x") < 4, pl.col("y") < 8), pl.lit("medium")),
         ],


### PR DESCRIPTION
Fixes: #14 

This PR renames the `caselist=` parameter to `case_list=` in `case_when()` to align with Polars' naming conventions.