### PR TITLE
refactor: `cycle()`

### DIFF
--- a/src/turtle_island/exprs/general.py
+++ b/src/turtle_island/exprs/general.py
@@ -543,7 +543,7 @@ def cycle(expr, offset: int = 1) -> pl.Expr:
     if offset == 0:
         return expr
     n = pl.len() - (offset % pl.len())
-    return expr.slice(n).append(expr.slice(0, n))
+    return expr.slice(n).append(expr.head(n))
 
 
 def make_concat_str(


### PR DESCRIPTION
This PR updates the internal implementation of `cycle()`, replacing `pl.expr.slice()` with `pl.expr.head()`.