### PR TITLE
refactor: accept an iterable as input for *args

### DIFF
--- a/src/turtle_island/_utils.py
+++ b/src/turtle_island/_utils.py
@@ -1,8 +1,11 @@
 import datetime
 import uuid
-from typing import Any, Collection
+from collections.abc import Iterable
+from typing import Any, Collection, TypeVar
 
 import polars as pl
+
+T = TypeVar("T")
 
 
 def _litify(items: Collection[Any]) -> list[pl.Expr]:
@@ -46,3 +49,14 @@ def _cast_datatype(expr: pl.Expr, item: Any) -> pl.Expr:
     elif isinstance(item, (list, tuple)):
         return expr.cast(pl.List)
     return expr
+
+
+def _flatten_elems(
+    elems: tuple[T | Iterable[T], ...],
+) -> tuple[T, ...]:
+    from polars._utils.parse.expr import _is_iterable
+
+    if len(elems) == 1 and _is_iterable(elems[0]):
+        return tuple(elems[0])  # type: ignore[arg-type]
+
+    return tuple(elems)  # type: ignore[arg-type]

--- a/tests/exprs/test_common.py
+++ b/tests/exprs/test_common.py
@@ -92,9 +92,15 @@ def test_case_when_all_forms(df_xy):
     assert_frame_equal(new_df, expected)
 
 
-def test_bulk_append(df_abcd):
-    exprs = [pl.col("a").last().cast(pl.Float64), pl.col("b").first()]
-    new_df = df_abcd.select(ti.bulk_append(*exprs))
+@pytest.mark.parametrize(
+    "exprs",
+    [
+        (pl.col("a").last().cast(pl.Float64), pl.col("b").first()),
+        ([pl.col("a").last().cast(pl.Float64), pl.col("b").first()]),
+    ],
+)
+def test_bulk_append(df_abcd, exprs):
+    new_df = df_abcd.select(ti.bulk_append(exprs))
     expected = pl.DataFrame({"a": [3.0, 1.11]})
 
     assert_frame_equal(new_df, expected)
@@ -131,9 +137,10 @@ def test_bulk_append_list_eval(df_xy_list):
     assert_frame_equal(new_df, expected)
 
 
-def test_bulk_append_raise():
+@pytest.mark.parametrize("exprs", [pl.lit(1), (pl.lit(1),)])
+def test_bulk_append_raise_one_element(exprs):
     with pytest.raises(ValueError) as exc_info:
-        ti.bulk_append(pl.lit(1))
+        ti.bulk_append(exprs)
 
     assert (
         "At least two Polars expressions must be provided."

--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -3,7 +3,12 @@ import datetime
 import polars as pl
 import pytest
 
-from turtle_island._utils import _cast_datatype, _get_unique_name, _litify
+from turtle_island._utils import (
+    _cast_datatype,
+    _flatten_elems,
+    _get_unique_name,
+    _litify,
+)
 
 
 @pytest.mark.parametrize("items", [(1, 2), (3.3, 4.4), ("x", "y")])
@@ -51,3 +56,25 @@ def test__get_unique_name_raise():
 def test__cast_datatype(df_abcd, item, expected):
     new_df = df_abcd.select(_cast_datatype(pl.col("a"), item))
     assert new_df.dtypes[0] == expected
+
+
+def test__flatten_elems():
+    exprs1 = _flatten_elems((pl.lit(1), pl.lit(2)))
+    exprs2 = _flatten_elems(((pl.lit(1), pl.lit(2)),))
+
+    assert isinstance(exprs1, tuple)
+    assert isinstance(exprs2, tuple)
+    assert len(exprs1) == len(exprs2)
+
+    for expr1, expr2 in zip(exprs1, exprs2):
+        assert expr1.meta.eq(expr2)
+
+
+def test__flatten_elems_one_element():
+    exprs1 = _flatten_elems((pl.lit(1),))
+    exprs2 = _flatten_elems(((pl.lit(1),),))
+
+    assert isinstance(exprs1, tuple)
+    assert isinstance(exprs2, tuple)
+
+    assert exprs1[0].meta.eq(exprs2[0])


### PR DESCRIPTION
Fixes: #36 

This PR updates the following functions to accept an iterable as their \*args:

* `bulk_append()`
* `bucketize()`
* `bucketize_lit()`
