### PR TITLE
fix: address deprecation warning when casting Int64 to list type

### DIFF
--- a/src/turtle_island/_utils.py
+++ b/src/turtle_island/_utils.py
@@ -47,7 +47,7 @@ def _cast_datatype(expr: pl.Expr, item: Any) -> pl.Expr:
         return expr.cast(pl.String)
     # TODO: Is it possible to cast dict -> pl.Struct here?
     elif isinstance(item, (list, tuple)):
-        return expr.cast(pl.List)
+        return pl.list(expr)
     return expr
 
 


### PR DESCRIPTION
Fixes #44.

This PR updates the internal `_cast_datatype()` function to address the deprecation warning introduced in Polars v1.43.0 by replacing the deprecated Int64-to-list casting logic with the recommended approach.